### PR TITLE
Copertura completa del protocollo Meshtastic

### DIFF
--- a/meshtasticd_client.py
+++ b/meshtasticd_client.py
@@ -151,10 +151,12 @@ async def get_node_config(db_path: str) -> dict:
             loop = asyncio.get_event_loop()
             def _read():
                 dc = _interface.localNode.localConfig.device
+                user = _interface.getMyUser() or {}
                 return {
                     'long_name': _interface.getLongName(),
                     'short_name': _interface.getShortName(),
                     'role': dc.Role.Name(dc.role),
+                    'is_licensed': bool(user.get('isLicensed', False)),
                 }
             data = await loop.run_in_executor(None, _read)
             data['cached'] = False
@@ -179,6 +181,13 @@ async def get_lora_config(db_path: str) -> dict:
                 return {
                     'region': lc.RegionCode.Name(lc.region),
                     'modem_preset': lc.ModemPreset.Name(lc.modem_preset),
+                    'hop_limit': lc.hop_limit,
+                    'tx_enabled': lc.tx_enabled,
+                    'tx_power': lc.tx_power,
+                    'channel_num': lc.channel_num,
+                    'override_duty_cycle': lc.override_duty_cycle,
+                    'sx126x_rx_boosted_gain': lc.sx126x_rx_boosted_gain,
+                    'ignore_mqtt': lc.ignore_mqtt,
                 }
             data = await loop.run_in_executor(None, _read)
             data['cached'] = False
@@ -208,6 +217,11 @@ async def get_channels(db_path: str) -> list[dict]:
                         'name': ch.settings.name,
                         'psk_b64': psk_b64,
                         'role': ch.Role.Name(ch.role),
+                        'uplink_enabled': ch.settings.uplink_enabled,
+                        'downlink_enabled': ch.settings.downlink_enabled,
+                        # 0 = precisione piena; 1-32 = bit di precisione della
+                        # posizione condivisa su questo canale
+                        'position_precision': ch.settings.module_settings.position_precision,
                     })
                 return result
             data = await loop.run_in_executor(None, _read)
@@ -278,36 +292,48 @@ def _write_local_config(section: str, updates: dict) -> None:
     node.writeConfig(section)
 
 
-def _do_set_node_config(long_name: str, short_name: str, role: str) -> None:
+def _do_set_node_config(long_name: str, short_name: str, role: str,
+                        is_licensed: bool = False) -> None:
     """Sync helper — runs in command queue thread."""
-    _interface.localNode.setOwner(long_name, short_name)
+    _interface.localNode.setOwner(long_name, short_name, is_licensed=is_licensed)
     from meshtastic.protobuf import config_pb2
     role_val = config_pb2.Config.DeviceConfig.Role.Value(role)
     _write_local_config('device', {'role': role_val})
 
 
-async def set_node_config(long_name: str, short_name: str, role: str) -> None:
+async def set_node_config(long_name: str, short_name: str, role: str,
+                          is_licensed: bool = False) -> None:
     """Queue node config write. Raises if board not connected."""
     if not _connected or not _interface:
         raise RuntimeError('Board not connected')
-    _ln, _sn, _r = long_name, short_name, role
-    await _command_queue.put(lambda: _do_set_node_config(_ln, _sn, _r))
+    _ln, _sn, _r, _lic = long_name, short_name, role, is_licensed
+    await _command_queue.put(lambda: _do_set_node_config(_ln, _sn, _r, _lic))
 
 
-def _do_set_lora_config(region: str, preset: str) -> None:
+def _do_set_lora_config(params: dict) -> None:
     """Sync helper — runs in command queue thread."""
     from meshtastic.protobuf import config_pb2
-    region_val = config_pb2.Config.LoRaConfig.RegionCode.Value(region)
-    preset_val = config_pb2.Config.LoRaConfig.ModemPreset.Value(preset)
-    _write_local_config('lora', {'region': region_val, 'modem_preset': preset_val})
+    _write_local_config('lora', {
+        'region': config_pb2.Config.LoRaConfig.RegionCode.Value(
+            params.get('region', 'UNSET')),
+        'modem_preset': config_pb2.Config.LoRaConfig.ModemPreset.Value(
+            params.get('modem_preset', 'LONG_FAST')),
+        'hop_limit': params.get('hop_limit', 3),
+        'tx_enabled': params.get('tx_enabled', True),
+        'tx_power': params.get('tx_power', 0),        # 0 = massimo consentito
+        'channel_num': params.get('channel_num', 0),  # 0 = slot dal nome canale
+        'override_duty_cycle': params.get('override_duty_cycle', False),
+        'sx126x_rx_boosted_gain': params.get('sx126x_rx_boosted_gain', False),
+        'ignore_mqtt': params.get('ignore_mqtt', False),
+    })
 
 
-async def set_lora_config(region: str, preset: str) -> None:
+async def set_lora_config(params: dict) -> None:
     """Queue LoRa config write. Raises if board not connected."""
     if not _connected or not _interface:
         raise RuntimeError('Board not connected')
-    _r, _p = region, preset
-    await _command_queue.put(lambda: _do_set_lora_config(_r, _p))
+    _p = dict(params)
+    await _command_queue.put(lambda: _do_set_lora_config(_p))
 
 
 async def send_waypoint(name: str, lat: float, lon: float,
@@ -802,22 +828,48 @@ async def set_serial_module_config(params: dict) -> None:
     await _command_queue.put(lambda: _do_set_serial_module_config(_p))
 
 
-def _do_set_channel(idx: int, name: str, psk_b64: str) -> None:
+def _do_set_channel(idx: int, params: dict) -> None:
     """Sync helper — runs in command queue thread."""
     import base64
+    from meshtastic.protobuf import channel_pb2
     ch = _interface.localNode.channels[idx]
-    ch.settings.name = name
-    if psk_b64:
-        ch.settings.psk = base64.b64decode(psk_b64)
+    ch.settings.name = params.get('name', '')
+    if params.get('psk_b64'):
+        ch.settings.psk = base64.b64decode(params['psk_b64'])
+    if params.get('role') is not None:
+        ch.role = channel_pb2.Channel.Role.Value(params['role'])
+    ch.settings.uplink_enabled = params.get('uplink_enabled', False)
+    ch.settings.downlink_enabled = params.get('downlink_enabled', False)
+    ch.settings.module_settings.position_precision = params.get('position_precision', 0)
     _interface.localNode.writeChannel(idx)
 
 
-async def set_channel(idx: int, name: str, psk_b64: str) -> None:
+async def set_channel(idx: int, params: dict) -> None:
     """Queue channel write. Raises if board not connected."""
     if not _connected or not _interface:
         raise RuntimeError('Board not connected')
-    _i, _n, _p = idx, name, psk_b64
-    await _command_queue.put(lambda: _do_set_channel(_i, _n, _p))
+    _i, _p = idx, dict(params)
+    await _command_queue.put(lambda: _do_set_channel(_i, _p))
+
+
+async def get_channel_url() -> str:
+    """URL condivisibile (https://meshtastic.org/e/#...) di canali+LoRa."""
+    if not _connected or not _interface:
+        raise RuntimeError('Board not connected')
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, lambda: _interface.localNode.getURL())
+
+
+async def set_channel_url(url: str, add_only: bool = False) -> None:
+    """Importa canali (e config LoRa) da un URL meshtastic.org/e/#.
+
+    Con add_only=True i canali dell'URL vengono aggiunti a quelli esistenti
+    invece di sostituirli.
+    """
+    if not _connected or not _interface:
+        raise RuntimeError('Board not connected')
+    _u, _a = url, add_only
+    await _command_queue.put(lambda: _interface.localNode.setURL(_u, addOnly=_a))
 
 
 # --- Device-level config sections (position, power, display, network, bluetooth, security) ---
@@ -1083,6 +1135,210 @@ async def set_security_config(params: dict) -> None:
         raise RuntimeError('Board not connected')
     _p = dict(params)
     await _command_queue.put(lambda: _do_set_security_config(_p))
+
+
+# --- Moduli restanti: audio, paxcounter, remote hardware ---
+
+AUDIO_DEFAULTS = {'codec2_enabled': False, 'ptt_pin': 0, 'bitrate': 'CODEC2_DEFAULT',
+                  'i2s_ws': 0, 'i2s_sd': 0, 'i2s_din': 0, 'i2s_sck': 0}
+
+
+async def get_audio_config(db_path: str) -> dict:
+    def _read():
+        mc = _interface.localNode.moduleConfig.audio
+        return {
+            'codec2_enabled': mc.codec2_enabled,
+            'ptt_pin': mc.ptt_pin,
+            'bitrate': mc.Audio_Baud.Name(mc.bitrate),
+            'i2s_ws': mc.i2s_ws, 'i2s_sd': mc.i2s_sd,
+            'i2s_din': mc.i2s_din, 'i2s_sck': mc.i2s_sck,
+        }
+    return await _get_cached_section(db_path, 'audio', _read, AUDIO_DEFAULTS)
+
+
+def _do_set_audio_config(params: dict) -> None:
+    from meshtastic.protobuf import module_config_pb2
+    _write_local_config('audio', {
+        'codec2_enabled': params.get('codec2_enabled', False),
+        'ptt_pin': params.get('ptt_pin', 0),
+        'bitrate': module_config_pb2.ModuleConfig.AudioConfig.Audio_Baud.Value(
+            params.get('bitrate', 'CODEC2_DEFAULT')),
+        'i2s_ws': params.get('i2s_ws', 0), 'i2s_sd': params.get('i2s_sd', 0),
+        'i2s_din': params.get('i2s_din', 0), 'i2s_sck': params.get('i2s_sck', 0),
+    })
+
+
+async def set_audio_config(params: dict) -> None:
+    if not _connected or not _interface:
+        raise RuntimeError('Board not connected')
+    _p = dict(params)
+    await _command_queue.put(lambda: _do_set_audio_config(_p))
+
+
+PAXCOUNTER_DEFAULTS = {'enabled': False, 'paxcounter_update_interval': 0,
+                       'wifi_threshold': 0, 'ble_threshold': 0}
+
+
+async def get_paxcounter_config(db_path: str) -> dict:
+    def _read():
+        mc = _interface.localNode.moduleConfig.paxcounter
+        return {
+            'enabled': mc.enabled,
+            'paxcounter_update_interval': mc.paxcounter_update_interval,
+            'wifi_threshold': mc.wifi_threshold,
+            'ble_threshold': mc.ble_threshold,
+        }
+    return await _get_cached_section(db_path, 'paxcounter', _read, PAXCOUNTER_DEFAULTS)
+
+
+def _do_set_paxcounter_config(params: dict) -> None:
+    _write_local_config('paxcounter', {
+        'enabled': params.get('enabled', False),
+        'paxcounter_update_interval': params.get('paxcounter_update_interval', 0),
+        'wifi_threshold': params.get('wifi_threshold', 0),
+        'ble_threshold': params.get('ble_threshold', 0),
+    })
+
+
+async def set_paxcounter_config(params: dict) -> None:
+    if not _connected or not _interface:
+        raise RuntimeError('Board not connected')
+    _p = dict(params)
+    await _command_queue.put(lambda: _do_set_paxcounter_config(_p))
+
+
+REMOTE_HARDWARE_DEFAULTS = {'enabled': False, 'allow_undefined_pin_access': False}
+
+
+async def get_remote_hardware_config(db_path: str) -> dict:
+    def _read():
+        mc = _interface.localNode.moduleConfig.remote_hardware
+        return {
+            'enabled': mc.enabled,
+            'allow_undefined_pin_access': mc.allow_undefined_pin_access,
+        }
+    return await _get_cached_section(db_path, 'remote_hardware', _read,
+                                     REMOTE_HARDWARE_DEFAULTS)
+
+
+def _do_set_remote_hardware_config(params: dict) -> None:
+    _write_local_config('remote_hardware', {
+        'enabled': params.get('enabled', False),
+        'allow_undefined_pin_access': params.get('allow_undefined_pin_access', False),
+    })
+
+
+async def set_remote_hardware_config(params: dict) -> None:
+    if not _connected or not _interface:
+        raise RuntimeError('Board not connected')
+    _p = dict(params)
+    await _command_queue.put(lambda: _do_set_remote_hardware_config(_p))
+
+
+# --- Utilità nodo: preferiti/ignorati, orario, reset NodeDB ---
+
+async def set_node_favorite(node_id: str, favorite: bool) -> None:
+    """Marca/smarca un nodo come preferito sulla board locale."""
+    if not _connected or not _interface:
+        raise RuntimeError('Board not connected')
+    _id, _fav = node_id, favorite
+
+    def _do():
+        if _fav:
+            _interface.localNode.setFavorite(_id)
+        else:
+            _interface.localNode.removeFavorite(_id)
+    await _command_queue.put(_do)
+
+
+async def set_node_ignored(node_id: str, ignored: bool) -> None:
+    """Ignora/de-ignora un nodo sulla board locale."""
+    if not _connected or not _interface:
+        raise RuntimeError('Board not connected')
+    _id, _ign = node_id, ignored
+
+    def _do():
+        if _ign:
+            _interface.localNode.setIgnored(_id)
+        else:
+            _interface.localNode.removeIgnored(_id)
+    await _command_queue.put(_do)
+
+
+async def sync_time() -> None:
+    """Imposta l'orologio della board dall'orario del Pi (RTC/NTP)."""
+    if not _connected or not _interface:
+        raise RuntimeError('Board not connected')
+    await _command_queue.put(lambda: _interface.localNode.setTime(int(time.time())))
+
+
+async def reset_nodedb() -> None:
+    """Svuota il NodeDB della board (l'anagrafica nodi ricomincia da zero)."""
+    if not _connected or not _interface:
+        raise RuntimeError('Board not connected')
+    await _command_queue.put(lambda: _interface.localNode.resetNodeDb())
+
+
+# --- Config remota: leggi/scrivi le sezioni di un nodo via mesh ---
+
+def _apply_updates(msg, updates: dict) -> None:
+    """Applica un dict a un messaggio protobuf, convertendo i nomi enum.
+
+    Ignora le chiavi sconosciute e i campi non scalari (bytes/sub-messaggi):
+    la UI remota lavora sugli stessi nomi campo dei form locali.
+    """
+    from google.protobuf.descriptor import FieldDescriptor
+    fields = {f.name: f for f in msg.DESCRIPTOR.fields}
+    for key, value in updates.items():
+        f = fields.get(key)
+        if f is None or f.type == FieldDescriptor.TYPE_BYTES \
+                or f.type == FieldDescriptor.TYPE_MESSAGE:
+            continue
+        if f.type == FieldDescriptor.TYPE_ENUM and isinstance(value, str):
+            value = f.enum_type.values_by_name[value].number
+        setattr(msg, key, value)
+
+
+REMOTE_CONFIG_TIMEOUT = 120  # s: un roundtrip admin sulla mesh può essere lento
+
+
+async def get_remote_config(node_id: str, section: str) -> dict:
+    """Legge una sezione config da un nodo remoto via admin mesh (lento)."""
+    if not _connected or not _interface:
+        raise RuntimeError('Board not connected')
+
+    def _read():
+        from google.protobuf.json_format import MessageToDict
+        node = _interface.getNode(node_id, requestChannels=False)
+        root = node.localConfig if section in _LOCAL_CONFIG_SECTIONS else node.moduleConfig
+        node.requestConfig(root.DESCRIPTOR.fields_by_name[section])
+        return MessageToDict(getattr(root, section), preserving_proto_field_name=True,
+                             always_print_fields_with_no_presence=True)
+
+    loop = asyncio.get_event_loop()
+    return await asyncio.wait_for(loop.run_in_executor(None, _read),
+                                  timeout=REMOTE_CONFIG_TIMEOUT)
+
+
+async def set_remote_config(node_id: str, section: str, updates: dict) -> None:
+    """Scrive una sezione config su un nodo remoto via admin mesh.
+
+    Prima rilegge la sezione dal nodo per non azzerare i campi non toccati,
+    poi applica gli update e la riscrive con writeConfig (session key PKC
+    gestita da getNode/_sendAdmin).
+    """
+    if not _connected or not _interface:
+        raise RuntimeError('Board not connected')
+    _id, _sec, _upd = node_id, section, dict(updates)
+
+    def _do():
+        node = _interface.getNode(_id, requestChannels=False)
+        root = node.localConfig if _sec in _LOCAL_CONFIG_SECTIONS else node.moduleConfig
+        node.requestConfig(root.DESCRIPTOR.fields_by_name[_sec])
+        _apply_updates(getattr(root, _sec), _upd)
+        node.writeConfig(_sec)
+
+    await _command_queue.put(_do)
 
 
 # --- Internal ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ jinja2>=3.1
 python-multipart>=0.0.9
 websockets>=13.0
 paho-mqtt>=2.0
+qrcode>=7.4

--- a/routers/admin_router.py
+++ b/routers/admin_router.py
@@ -55,3 +55,42 @@ async def admin_factory_reset(node_id: str):
         return {'ok': True}
     except RuntimeError as e:
         return JSONResponse({'error': str(e)}, status_code=400)
+
+
+# ─── Config remota: leggi/scrivi le sezioni config di un nodo via mesh ──
+
+# Sezioni ammesse (protobuf LocalConfig + ModuleConfig)
+_REMOTE_SECTIONS = frozenset({
+    'device', 'position', 'power', 'network', 'display', 'lora', 'bluetooth',
+    'security', 'mqtt', 'serial', 'external_notification', 'store_forward',
+    'range_test', 'telemetry', 'canned_message', 'audio', 'remote_hardware',
+    'neighbor_info', 'ambient_lighting', 'detection_sensor', 'paxcounter',
+})
+
+
+@router.get('/api/admin/{node_id}/config/{section}')
+async def get_remote_config(node_id: str, section: str):
+    """Legge una sezione config dal nodo remoto (roundtrip mesh: lento)."""
+    if section not in _REMOTE_SECTIONS:
+        raise HTTPException(status_code=400, detail=f'sezione sconosciuta: {section}')
+    try:
+        data = await meshtasticd_client.get_remote_config(node_id, section)
+        data['cached'] = False
+        return data
+    except TimeoutError:
+        return JSONResponse({'error': 'timeout: il nodo non ha risposto'}, status_code=504)
+    except RuntimeError as e:
+        return JSONResponse({'error': str(e)}, status_code=503)
+
+
+@router.post('/api/admin/{node_id}/config/{section}')
+async def set_remote_config(node_id: str, section: str, body: dict):
+    """Scrive una sezione config sul nodo remoto (rilegge, applica, riscrive)."""
+    if section not in _REMOTE_SECTIONS:
+        raise HTTPException(status_code=400, detail=f'sezione sconosciuta: {section}')
+    body.pop('cached', None)
+    try:
+        await meshtasticd_client.set_remote_config(node_id, section, body)
+        return {'ok': True}
+    except RuntimeError as e:
+        return JSONResponse({'error': str(e)}, status_code=503)

--- a/routers/config_router.py
+++ b/routers/config_router.py
@@ -78,12 +78,14 @@ class NodeConfigRequest(BaseModel):
     long_name: str
     short_name: str
     role: str
+    is_licensed: bool = False   # modalità radioamatore (nomi in chiaro, no PSK)
 
 
 @router.post('/api/config/node')
 async def post_node_config(body: NodeConfigRequest):
     try:
-        await meshtasticd_client.set_node_config(body.long_name, body.short_name, body.role)
+        await meshtasticd_client.set_node_config(
+            body.long_name, body.short_name, body.role, body.is_licensed)
         return {'ok': True}
     except RuntimeError as e:
         return JSONResponse({'error': str(e)}, status_code=503)
@@ -97,12 +99,21 @@ async def get_lora_config():
 class LoraConfigRequest(BaseModel):
     region: str
     modem_preset: str
+    hop_limit: int = 3
+    tx_enabled: bool = True
+    tx_power: int = 0            # dBm, 0 = massimo consentito dalla regione
+    channel_num: int = 0         # frequency slot, 0 = derivato dal nome canale
+    override_duty_cycle: bool = False
+    sx126x_rx_boosted_gain: bool = False
+    ignore_mqtt: bool = False
 
 
 @router.post('/api/config/lora')
 async def post_lora_config(body: LoraConfigRequest):
+    if not (0 <= body.hop_limit <= 7):
+        return JSONResponse({'error': 'hop_limit deve essere 0-7'}, status_code=400)
     try:
-        await meshtasticd_client.set_lora_config(body.region, body.modem_preset)
+        await meshtasticd_client.set_lora_config(body.model_dump())
         return {'ok': True}
     except RuntimeError as e:
         return JSONResponse({'error': str(e)}, status_code=503)
@@ -116,15 +127,68 @@ async def get_channels():
 class ChannelRequest(BaseModel):
     name: str
     psk_b64: str = ''
+    role: str = 'SECONDARY'          # PRIMARY / SECONDARY / DISABLED
+    uplink_enabled: bool = False     # canale → MQTT
+    downlink_enabled: bool = False   # MQTT → canale
+    position_precision: int = 0      # 0 = piena, 1-32 bit di precisione
+
+
+class ChannelUrlRequest(BaseModel):
+    url: str
+    add_only: bool = False           # True: aggiungi ai canali esistenti
+
+
+@router.get('/api/config/channels/url')
+async def get_channels_url():
+    """URL condivisibile meshtastic.org/e/# con canali attivi + config LoRa."""
+    try:
+        return {'url': await meshtasticd_client.get_channel_url()}
+    except RuntimeError as e:
+        return JSONResponse({'error': str(e)}, status_code=503)
+
+
+@router.post('/api/config/channels/url')
+async def post_channels_url(body: ChannelUrlRequest):
+    """Importa canali da un URL condiviso (sostituisce o aggiunge)."""
+    if '#' not in body.url or 'meshtastic' not in body.url.lower():
+        return JSONResponse({'error': 'URL non valido: atteso meshtastic.org/e/#...'},
+                            status_code=400)
+    try:
+        await meshtasticd_client.set_channel_url(body.url, body.add_only)
+        return {'ok': True, 'reboot_required': True}
+    except RuntimeError as e:
+        return JSONResponse({'error': str(e)}, status_code=503)
+
+
+@router.get('/api/config/channels/qr')
+async def get_channels_qr():
+    """QR code SVG dell'URL di condivisione canali."""
+    from fastapi.responses import Response
+    import io
+    import qrcode
+    import qrcode.image.svg
+    try:
+        url = await meshtasticd_client.get_channel_url()
+    except RuntimeError as e:
+        return JSONResponse({'error': str(e)}, status_code=503)
+    img = qrcode.make(url, image_factory=qrcode.image.svg.SvgPathImage, box_size=12)
+    buf = io.BytesIO()
+    img.save(buf)
+    return Response(content=buf.getvalue(), media_type='image/svg+xml')
 
 
 @router.post('/api/config/channels/{idx}')
 async def post_channel(idx: int, body: ChannelRequest):
+    if body.role not in ('PRIMARY', 'SECONDARY', 'DISABLED'):
+        return JSONResponse({'error': 'role non valido'}, status_code=400)
+    if not (0 <= body.position_precision <= 32):
+        return JSONResponse({'error': 'position_precision deve essere 0-32'}, status_code=400)
     try:
-        await meshtasticd_client.set_channel(idx, body.name, body.psk_b64)
+        await meshtasticd_client.set_channel(idx, body.model_dump())
         return {'ok': True}
     except RuntimeError as e:
         return JSONResponse({'error': str(e)}, status_code=503)
+
 
 
 @router.get('/api/config/gpio')
@@ -576,6 +640,26 @@ async def set_serial_port(body: SerialPortRequest):
     _write_env('SERIAL_PATH', body.port)
     cfg.SERIAL_PATH = body.port
     return {'ok': True, 'port': body.port, 'restart_required': True}
+
+
+@router.post('/api/system/sync-time')
+async def system_sync_time():
+    """Sincronizza l'orologio della board dall'orario del Pi."""
+    try:
+        await meshtasticd_client.sync_time()
+        return {'ok': True}
+    except RuntimeError as e:
+        return JSONResponse({'error': str(e)}, status_code=503)
+
+
+@router.post('/api/system/reset-nodedb')
+async def system_reset_nodedb():
+    """Svuota il NodeDB della board (irreversibile ma non distruttivo)."""
+    try:
+        await meshtasticd_client.reset_nodedb()
+        return {'ok': True}
+    except RuntimeError as e:
+        return JSONResponse({'error': str(e)}, status_code=503)
 
 
 @router.post('/api/system/reboot')

--- a/routers/module_config_router.py
+++ b/routers/module_config_router.py
@@ -219,3 +219,77 @@ async def set_serial_module(body: SerialModuleConfig):
         return {'ok': True}
     except RuntimeError as e:
         return JSONResponse({'error': str(e)}, status_code=503)
+
+
+# ─── Audio (codec2 voice) ──────────────────────────────────────────────
+@router.get('/api/config/module/audio')
+async def get_audio():
+    return await meshtasticd_client.get_audio_config(cfg.DB_PATH)
+
+
+class AudioConfig(BaseModel):
+    codec2_enabled: bool = False
+    ptt_pin: int = 0
+    bitrate: str = 'CODEC2_DEFAULT'
+    i2s_ws: int = 0
+    i2s_sd: int = 0
+    i2s_din: int = 0
+    i2s_sck: int = 0
+
+
+_AUDIO_BITRATES = ('CODEC2_DEFAULT', 'CODEC2_3200', 'CODEC2_2400', 'CODEC2_1600',
+                   'CODEC2_1400', 'CODEC2_1300', 'CODEC2_1200', 'CODEC2_700',
+                   'CODEC2_700B')
+
+
+@router.post('/api/config/module/audio')
+async def set_audio(body: AudioConfig):
+    if body.bitrate not in _AUDIO_BITRATES:
+        return JSONResponse({'error': 'bitrate non valido'}, status_code=400)
+    try:
+        await meshtasticd_client.set_audio_config(body.model_dump())
+        return {'ok': True}
+    except RuntimeError as e:
+        return JSONResponse({'error': str(e)}, status_code=503)
+
+
+# ─── Paxcounter (conteggio dispositivi WiFi/BLE) ───────────────────────
+@router.get('/api/config/module/paxcounter')
+async def get_paxcounter():
+    return await meshtasticd_client.get_paxcounter_config(cfg.DB_PATH)
+
+
+class PaxcounterConfig(BaseModel):
+    enabled: bool = False
+    paxcounter_update_interval: int = 0
+    wifi_threshold: int = 0
+    ble_threshold: int = 0
+
+
+@router.post('/api/config/module/paxcounter')
+async def set_paxcounter(body: PaxcounterConfig):
+    try:
+        await meshtasticd_client.set_paxcounter_config(body.model_dump())
+        return {'ok': True}
+    except RuntimeError as e:
+        return JSONResponse({'error': str(e)}, status_code=503)
+
+
+# ─── Remote Hardware (GPIO via mesh) ───────────────────────────────────
+@router.get('/api/config/module/remote-hardware')
+async def get_remote_hardware():
+    return await meshtasticd_client.get_remote_hardware_config(cfg.DB_PATH)
+
+
+class RemoteHardwareConfig(BaseModel):
+    enabled: bool = False
+    allow_undefined_pin_access: bool = False
+
+
+@router.post('/api/config/module/remote-hardware')
+async def set_remote_hardware(body: RemoteHardwareConfig):
+    try:
+        await meshtasticd_client.set_remote_hardware_config(body.model_dump())
+        return {'ok': True}
+    except RuntimeError as e:
+        return JSONResponse({'error': str(e)}, status_code=503)

--- a/routers/nodes.py
+++ b/routers/nodes.py
@@ -32,3 +32,23 @@ async def api_nodes():
 async def delete_node(node_id: str, purge: bool = False):
     await database.delete_node(cfg.DB_PATH, node_id, purge=purge)
     return {'ok': True}
+
+
+@router.post('/api/nodes/{node_id}/favorite')
+async def set_favorite(node_id: str, on: bool = True):
+    """Marca (?on=true, default) o smarca (?on=false) un nodo come preferito."""
+    try:
+        await meshtasticd_client.set_node_favorite(node_id, on)
+        return {'ok': True}
+    except RuntimeError as e:
+        return JSONResponse({'error': str(e)}, status_code=503)
+
+
+@router.post('/api/nodes/{node_id}/ignore')
+async def set_ignored(node_id: str, on: bool = True):
+    """Ignora (?on=true, default) o de-ignora (?on=false) un nodo."""
+    try:
+        await meshtasticd_client.set_node_ignored(node_id, on)
+        return {'ok': True}
+    except RuntimeError as e:
+        return JSONResponse({'error': str(e)}, status_code=503)

--- a/static/config.js
+++ b/static/config.js
@@ -24,6 +24,8 @@ function configPage() {
         { id: 'cannedmod', label: 'CannedMod' }, { id: 'rangetest', label: 'RangeTest' },
         { id: 'detsensor', label: 'DetSensor' }, { id: 'ambilight', label: 'AmbLight' },
         { id: 'neighinfo', label: 'Neighbor' }, { id: 'serial', label: 'Serial' },
+        { id: 'audio', label: 'Audio' }, { id: 'paxcounter', label: 'Paxcounter' },
+        { id: 'remotehw', label: 'RemoteHW' },
       ]},
       { id: 'pi', label: 'Pi', sections: [
         { id: 'gpio', label: 'GPIO' }, { id: 'rtc', label: 'RTC' }, { id: 'usb', label: 'USB' },
@@ -57,7 +59,13 @@ function configPage() {
     rangeTest: {}, detSensor: {}, ambLight: {}, neighInfo: {}, serialMod: {},
     devPosition: {}, devPower: {}, devDisplay: {}, devNetwork: {},
     devBluetooth: {}, devSecurity: {},
+    audioMod: {}, paxMod: {}, remoteHw: {},
     moduleStatus: '',
+    // Condivisione canali (URL/QR meshtastic.org/e/#)
+    chUrl: '', chImportUrl: '', chAddOnly: false, chQrVisible: false,
+    // Config remota: 'local' oppure id nodo (!aabbccdd). Le sezioni board
+    // remote-capable vengono lette/scritte via /api/admin/{id}/config/{sez}.
+    target: 'local', targetNodes: [],
 
     loaded: { node: false, lora: false, channels: false },
     saving: { node: false, lora: false, channels: false },
@@ -66,6 +74,7 @@ function configPage() {
     async init() {
       await this.loadNode()
       await this.scanSerialPorts()
+      await this.loadTargets()
     },
 
     async selectSection(s, groupId) {
@@ -97,11 +106,121 @@ function configPage() {
       if (s === 'network')   await this.loadDevSection('network', 'devNetwork')
       if (s === 'bluetooth') await this.loadDevSection('bluetooth', 'devBluetooth')
       if (s === 'security')  await this.loadDevSection('security', 'devSecurity')
+      if (s === 'audio')     await this.loadModSection('/api/config/module/audio', 'audioMod')
+      if (s === 'paxcounter') await this.loadModSection('/api/config/module/paxcounter', 'paxMod')
+      if (s === 'remotehw')  await this.loadModSection('/api/config/module/remote-hardware', 'remoteHw')
+      if (s === 'channels' && !this.channelsCached) await this.loadChannelUrl()
+    },
+
+    async loadModSection(endpoint, prop) {
+      if (this.target !== 'local') this.moduleStatus = '⏳ lettura dal nodo remoto…'
+      const r = await fetch(this.cfgEndpoint(endpoint))
+      if (r.ok) this[prop] = await r.json()
+      if (this.target !== 'local') this.moduleStatus = r.ok ? '' : '✗ nodo non raggiungibile'
+    },
+
+    // endpoint locale → nome sezione protobuf per la config remota
+    _remoteSections: {
+      '/api/config/lora': 'lora',
+      '/api/config/mqtt': 'mqtt',
+      '/api/config/device/position': 'position',
+      '/api/config/device/power': 'power',
+      '/api/config/device/display': 'display',
+      '/api/config/device/network': 'network',
+      '/api/config/device/bluetooth': 'bluetooth',
+      '/api/config/device/security': 'security',
+      '/api/config/module/external-notification': 'external_notification',
+      '/api/config/module/store-forward': 'store_forward',
+      '/api/config/module/telemetry': 'telemetry',
+      '/api/config/module/canned-message': 'canned_message',
+      '/api/config/module/range-test': 'range_test',
+      '/api/config/module/detection-sensor': 'detection_sensor',
+      '/api/config/module/ambient-lighting': 'ambient_lighting',
+      '/api/config/module/neighbor-info': 'neighbor_info',
+      '/api/config/module/serial': 'serial',
+      '/api/config/module/audio': 'audio',
+      '/api/config/module/paxcounter': 'paxcounter',
+      '/api/config/module/remote-hardware': 'remote_hardware',
+    },
+
+    // Se il target è un nodo remoto, ridirige l'endpoint sull'API admin.
+    cfgEndpoint(url) {
+      if (this.target === 'local') return url
+      const sec = this._remoteSections[url]
+      return sec ? `/api/admin/${this.target}/config/${sec}` : url
+    },
+
+    remoteCapable() {
+      // sezioni con almeno un endpoint remotizzabile (tutte le board tranne
+      // node/canali, che restano locali)
+      return ['lora','mqtt','position','power','devdisplay','network','bluetooth',
+              'security','extnotif','sf','telmod','cannedmod','rangetest',
+              'detsensor','ambilight','neighinfo','serial','audio','paxcounter',
+              'remotehw'].includes(this.section)
+    },
+
+    async loadTargets() {
+      const r = await fetch('/api/nodes')
+      if (r.ok) {
+        const nodes = await r.json()
+        this.targetNodes = nodes.filter(n => !n.is_local)
+      }
+    },
+
+    async setTarget(t) {
+      this.target = t
+      // ricarica la sezione corrente dal nuovo target
+      await this.selectSection(this.section)
     },
 
     async loadDevSection(endpoint, prop) {
-      const r = await fetch(`/api/config/device/${endpoint}`)
+      if (this.target !== 'local') this.moduleStatus = '⏳ lettura dal nodo remoto…'
+      const r = await fetch(this.cfgEndpoint(`/api/config/device/${endpoint}`))
       if (r.ok) this[prop] = await r.json()
+      else this[prop] = {}
+      if (this.target !== 'local') this.moduleStatus = r.ok ? '' : '✗ nodo non raggiungibile'
+    },
+
+    // --- Condivisione canali (URL / QR) ---
+    async loadChannelUrl() {
+      const r = await fetch('/api/config/channels/url')
+      this.chUrl = r.ok ? (await r.json()).url : ''
+    },
+
+    async copyChannelUrl() {
+      try {
+        await navigator.clipboard.writeText(this.chUrl)
+        this.status.channels = '✓ URL copiato'
+      } catch (e) {
+        this.status.channels = '✗ Copia non disponibile'
+      }
+    },
+
+    async importChannelUrl() {
+      if (!this.chImportUrl.includes('#')) {
+        this.status.channels = '✗ URL non valido'
+        return
+      }
+      const r = await fetch('/api/config/channels/url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: this.chImportUrl, add_only: this.chAddOnly })
+      })
+      const data = await r.json()
+      this.status.channels = r.ok ? '✓ Canali importati — riavvio consigliato' : '✗ ' + (data.error || 'Errore')
+      if (r.ok) { this.chImportUrl = ''; await this.loadChannels(); await this.loadChannelUrl() }
+    },
+
+    // --- Utilità board (sezione Nodo) ---
+    async syncTime() {
+      const r = await fetch('/api/system/sync-time', { method: 'POST' })
+      this.status.node = r.ok ? '✓ Orario sincronizzato' : '✗ Board non connessa'
+    },
+
+    async resetNodeDb() {
+      if (!confirm("Svuotare l'anagrafica nodi della board? I nodi verranno riscoperti dalla mesh.")) return
+      const r = await fetch('/api/system/reset-nodedb', { method: 'POST' })
+      this.status.node = r.ok ? '✓ NodeDB azzerato' : '✗ Board non connessa'
     },
 
     async loadNode() {
@@ -111,7 +230,7 @@ function configPage() {
     },
 
     async loadLora() {
-      const r = await fetch('/api/config/lora')
+      const r = await fetch(this.cfgEndpoint('/api/config/lora'))
       if (r.ok) this.lora = await r.json()
       this.loaded.lora = true
     },
@@ -149,7 +268,7 @@ function configPage() {
         const r = await fetch('/api/config/node', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ long_name: this.node.long_name, short_name: this.node.short_name, role: this.node.role })
+          body: JSON.stringify({ long_name: this.node.long_name, short_name: this.node.short_name, role: this.node.role, is_licensed: !!this.node.is_licensed })
         })
         const data = await r.json()
         this.status.node = r.ok ? '✓ Salvato' : '✗ ' + (data.error || 'Errore')
@@ -196,8 +315,10 @@ function configPage() {
     },
 
     async saveLora() {
-      const validRegions = ['EU_868','US','EU_433','CN']
-      const validPresets = ['LONG_FAST','LONG_SLOW','MEDIUM_FAST','SHORT_FAST']
+      const validRegions = ['UNSET','US','EU_433','EU_868','CN','JP','ANZ','KR','TW','RU',
+                            'IN','NZ_865','TH','LORA_24','UA_433','UA_868','MY_433','MY_919','SG_923']
+      const validPresets = ['LONG_FAST','LONG_SLOW','VERY_LONG_SLOW','MEDIUM_SLOW',
+                            'MEDIUM_FAST','SHORT_SLOW','SHORT_FAST','SHORT_TURBO']
       if (!validRegions.includes(this.lora.region)) {
         this.status.lora = '✗ Regione non valida'
         return
@@ -209,10 +330,17 @@ function configPage() {
       this.saving.lora = true
       this.status.lora = ''
       try {
-        const r = await fetch('/api/config/lora', {
+        const r = await fetch(this.cfgEndpoint('/api/config/lora'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ region: this.lora.region, modem_preset: this.lora.modem_preset })
+          body: JSON.stringify({
+            region: this.lora.region, modem_preset: this.lora.modem_preset,
+            hop_limit: this.lora.hop_limit ?? 3, tx_enabled: this.lora.tx_enabled ?? true,
+            tx_power: this.lora.tx_power ?? 0, channel_num: this.lora.channel_num ?? 0,
+            override_duty_cycle: !!this.lora.override_duty_cycle,
+            sx126x_rx_boosted_gain: !!this.lora.sx126x_rx_boosted_gain,
+            ignore_mqtt: !!this.lora.ignore_mqtt,
+          })
         })
         const data = await r.json()
         this.status.lora = r.ok ? '✓ Salvato' : '✗ ' + (data.error || 'Errore')
@@ -235,7 +363,11 @@ function configPage() {
       const r = await fetch(`/api/config/channels/${idx}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: ch.name, psk_b64: ch.psk_b64 || '' })
+        body: JSON.stringify({
+          name: ch.name, psk_b64: ch.psk_b64 || '', role: ch.role || 'SECONDARY',
+          uplink_enabled: !!ch.uplink_enabled, downlink_enabled: !!ch.downlink_enabled,
+          position_precision: ch.position_precision ?? 0,
+        })
       })
       const data = await r.json()
       this.status.channels = r.ok ? `✓ CH${idx} salvato` : '✗ ' + (data.error || 'Errore')
@@ -711,7 +843,7 @@ function configPage() {
     },
 
     async loadMqtt() {
-      const r = await fetch('/api/config/mqtt')
+      const r = await fetch(this.cfgEndpoint('/api/config/mqtt'))
       if (r.ok) this.mqtt = await r.json()
     },
 
@@ -724,7 +856,7 @@ function configPage() {
       this.mqttSaving = true
       this.status.mqtt = ''
       try {
-        const r = await fetch('/api/config/mqtt', {
+        const r = await fetch(this.cfgEndpoint('/api/config/mqtt'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -775,7 +907,8 @@ function configPage() {
     },
 
     async saveModule(endpoint, data) {
-      const r = await fetch(endpoint, {
+      if (this.target !== 'local') this.moduleStatus = '⏳ scrittura sul nodo remoto…'
+      const r = await fetch(this.cfgEndpoint(endpoint), {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify(data)
@@ -785,39 +918,39 @@ function configPage() {
     },
 
     async loadExtNotif() {
-      const r = await fetch('/api/config/module/external-notification')
+      const r = await fetch(this.cfgEndpoint('/api/config/module/external-notification'))
       if (r.ok) this.extNotif = await r.json()
     },
     async loadStoreForward() {
-      const r = await fetch('/api/config/module/store-forward')
+      const r = await fetch(this.cfgEndpoint('/api/config/module/store-forward'))
       if (r.ok) this.storeForward = await r.json()
     },
     async loadTelMod() {
-      const r = await fetch('/api/config/module/telemetry')
+      const r = await fetch(this.cfgEndpoint('/api/config/module/telemetry'))
       if (r.ok) this.telMod = await r.json()
     },
     async loadCannedMod() {
-      const r = await fetch('/api/config/module/canned-message')
+      const r = await fetch(this.cfgEndpoint('/api/config/module/canned-message'))
       if (r.ok) this.cannedMod = await r.json()
     },
     async loadRangeTest() {
-      const r = await fetch('/api/config/module/range-test')
+      const r = await fetch(this.cfgEndpoint('/api/config/module/range-test'))
       if (r.ok) this.rangeTest = await r.json()
     },
     async loadDetSensor() {
-      const r = await fetch('/api/config/module/detection-sensor')
+      const r = await fetch(this.cfgEndpoint('/api/config/module/detection-sensor'))
       if (r.ok) this.detSensor = await r.json()
     },
     async loadAmbLight() {
-      const r = await fetch('/api/config/module/ambient-lighting')
+      const r = await fetch(this.cfgEndpoint('/api/config/module/ambient-lighting'))
       if (r.ok) this.ambLight = await r.json()
     },
     async loadNeighInfo() {
-      const r = await fetch('/api/config/module/neighbor-info')
+      const r = await fetch(this.cfgEndpoint('/api/config/module/neighbor-info'))
       if (r.ok) this.neighInfo = await r.json()
     },
     async loadSerialMod() {
-      const r = await fetch('/api/config/module/serial')
+      const r = await fetch(this.cfgEndpoint('/api/config/module/serial'))
       if (r.ok) this.serialMod = await r.json()
     },
   }

--- a/templates/config.html
+++ b/templates/config.html
@@ -43,6 +43,20 @@
   <!-- CONTENT AREA -->
   <div class="cfg-content" style="flex:1;overflow-y:auto;padding:12px 14px;display:flex;flex-direction:column;gap:10px;">
 
+    <!-- Config remota: scegli quale board configurare (locale o via mesh) -->
+    <div x-show="remoteCapable() && targetNodes.length > 0"
+         style="display:flex;align-items:center;gap:8px;background:var(--panel);border:1px solid var(--border);border-radius:6px;padding:6px 10px;">
+      <span style="font-size:10px;color:var(--muted);white-space:nowrap;">Board:</span>
+      <select :value="target" @change="setTarget($event.target.value)"
+              style="flex:1;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:5px 8px;font-size:11px;">
+        <option value="local">Locale (USB)</option>
+        <template x-for="n in targetNodes" :key="n.id">
+          <option :value="n.id" x-text="(n.short_name || n.id) + ' — via mesh'"></option>
+        </template>
+      </select>
+      <span x-show="target !== 'local'" style="font-size:9px;color:#ff9800;white-space:nowrap;">⏳ lento (mesh)</span>
+    </div>
+
     {% include 'config/_board.html' %}
     {% include 'config/_pi.html' %}
     {% include 'config/_ui.html' %}

--- a/templates/config/_board.html
+++ b/templates/config/_board.html
@@ -42,18 +42,33 @@
                     style="background:var(--panel);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:7px 8px;font-size:12px;">
               <option value="CLIENT">Client</option>
               <option value="CLIENT_MUTE">Client (muto)</option>
+              <option value="CLIENT_HIDDEN">Client (nascosto)</option>
               <option value="ROUTER">Router</option>
-              <option value="ROUTER_CLIENT">Router+Client</option>
+              <option value="ROUTER_LATE">Router (late)</option>
               <option value="REPEATER">Repeater</option>
               <option value="TRACKER">Tracker</option>
+              <option value="SENSOR">Sensor</option>
+              <option value="TAK">TAK</option>
+              <option value="TAK_TRACKER">TAK Tracker</option>
+              <option value="LOST_AND_FOUND">Lost &amp; Found</option>
             </select>
           </div>
+          <label class="cfg-check"><input type="checkbox" x-model="node.is_licensed">
+            Modalità radioamatore (is_licensed) — nomi in chiaro, niente crittografia</label>
           <button @click="saveNode()"
                   :disabled="node.cached || saving.node"
                   style="padding:10px;font-size:12px;border:none;border-radius:6px;cursor:pointer;font-weight:600;"
                   :style="node.cached ? 'background:var(--border);color:var(--muted);cursor:not-allowed;' : 'background:var(--accent);color:#fff;'"
                   x-text="saving.node ? 'Salvataggio...' : (node.cached ? 'Board non connessa' : 'Salva nodo')">
           </button>
+          <div class="cfg-row">
+            <button @click="syncTime()" class="btn-accent" style="background:var(--panel);color:var(--text);border:1px solid var(--border);">
+              Sincronizza orario dal Pi
+            </button>
+            <button @click="resetNodeDb()" class="btn-accent" style="background:var(--panel);color:#ff9800;border:1px solid var(--border);">
+              Azzera NodeDB
+            </button>
+          </div>
           <button @click="factoryModal = true"
                   style="padding:10px;font-size:12px;border:none;border-radius:6px;cursor:pointer;font-weight:600;background:#ef4444;color:#fff;margin-top:4px;">
             Factory Reset
@@ -78,9 +93,23 @@
             <select x-model="lora.region"
                     style="background:var(--panel);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:7px 8px;font-size:12px;">
               <option value="EU_868">EU 868MHz</option>
-              <option value="US">US 915MHz</option>
               <option value="EU_433">EU 433MHz</option>
+              <option value="US">US 915MHz</option>
+              <option value="ANZ">ANZ 915MHz</option>
               <option value="CN">CN 470MHz</option>
+              <option value="JP">JP 920MHz</option>
+              <option value="KR">KR 920MHz</option>
+              <option value="TW">TW 923MHz</option>
+              <option value="RU">RU 868MHz</option>
+              <option value="IN">IN 865MHz</option>
+              <option value="NZ_865">NZ 865MHz</option>
+              <option value="TH">TH 920MHz</option>
+              <option value="UA_433">UA 433MHz</option>
+              <option value="UA_868">UA 868MHz</option>
+              <option value="MY_433">MY 433MHz</option>
+              <option value="MY_919">MY 919MHz</option>
+              <option value="SG_923">SG 923MHz</option>
+              <option value="LORA_24">LoRa 2.4GHz</option>
             </select>
           </div>
           <div style="display:flex;flex-direction:column;gap:3px;">
@@ -89,10 +118,23 @@
                     style="background:var(--panel);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:7px 8px;font-size:12px;">
               <option value="LONG_FAST">Long Fast</option>
               <option value="LONG_SLOW">Long Slow</option>
+              <option value="VERY_LONG_SLOW">Very Long Slow</option>
+              <option value="MEDIUM_SLOW">Medium Slow</option>
               <option value="MEDIUM_FAST">Medium Fast</option>
+              <option value="SHORT_SLOW">Short Slow</option>
               <option value="SHORT_FAST">Short Fast</option>
+              <option value="SHORT_TURBO">Short Turbo</option>
             </select>
           </div>
+          <div class="cfg-row">
+            {{ f.number('lora.hop_limit', 'Hop limit (0-7)', width='70px', min=0, max=7) }}
+            {{ f.number('lora.tx_power', 'TX power (dBm, 0=max)', width='90px') }}
+            {{ f.number('lora.channel_num', 'Frequency slot (0=auto)', width='90px') }}
+          </div>
+          {{ f.toggle('lora.tx_enabled', 'Trasmissione abilitata') }}
+          {{ f.toggle('lora.override_duty_cycle', 'Ignora duty cycle (occhio alle norme regionali!)') }}
+          {{ f.toggle('lora.sx126x_rx_boosted_gain', 'RX boosted gain (SX126x)') }}
+          {{ f.toggle('lora.ignore_mqtt', 'Ignora messaggi provenienti da MQTT') }}
           <button @click="saveLora()"
                   :disabled="lora.cached || saving.lora"
                   style="padding:10px;font-size:12px;border:none;border-radius:6px;cursor:pointer;font-weight:600;"
@@ -116,6 +158,28 @@
         <template x-if="channels.length === 0">
           <p style="font-size:11px;color:var(--muted);">Nessun canale — board offline o non configurata.</p>
         </template>
+
+        <!-- Condivisione canali: URL + QR + import -->
+        <div x-show="!channelsCached" style="background:var(--panel);border:1px solid var(--border);border-radius:6px;padding:10px;margin-bottom:10px;">
+          <div style="font-size:10px;font-weight:700;color:var(--accent);margin-bottom:6px;">CONDIVIDI CANALI</div>
+          <div class="cfg-row" style="align-items:center;">
+            <input :value="chUrl" readonly class="cfg-input" style="flex:1;font-size:10px;font-family:monospace;min-width:180px;">
+            <button @click="copyChannelUrl()" class="btn-accent" style="padding:6px 10px;">Copia</button>
+            <button @click="chQrVisible = !chQrVisible" class="btn-accent"
+                    style="padding:6px 10px;background:var(--bg);color:var(--text);border:1px solid var(--border);"
+                    x-text="chQrVisible ? 'Nascondi QR' : 'Mostra QR'"></button>
+          </div>
+          <div x-show="chQrVisible" style="margin-top:8px;text-align:center;background:#fff;border-radius:6px;padding:8px;">
+            <img src="/api/config/channels/qr" alt="QR canali" style="max-width:220px;width:100%;">
+          </div>
+          <div style="height:1px;background:var(--border);margin:10px 0;"></div>
+          <div style="font-size:10px;font-weight:700;color:var(--accent);margin-bottom:6px;">IMPORTA DA URL</div>
+          <div class="cfg-col">
+            <input x-model="chImportUrl" placeholder="https://meshtastic.org/e/#..." class="cfg-input" style="font-size:10px;font-family:monospace;">
+            <label class="cfg-check"><input type="checkbox" x-model="chAddOnly"> Aggiungi ai canali esistenti (invece di sostituirli)</label>
+            <button @click="importChannelUrl()" class="btn-accent">Importa canali</button>
+          </div>
+        </div>
         <template x-for="ch in channels" :key="ch.index">
           <div style="background:var(--panel);border:1px solid var(--border);border-radius:6px;padding:10px;margin-bottom:8px;">
             <div style="font-size:10px;color:var(--muted);margin-bottom:6px;" x-text="'CH ' + ch.index + ' — ' + ch.role"></div>
@@ -129,6 +193,21 @@
                 <input x-model="ch.psk_b64" placeholder="lascia vuoto = non cambiare"
                        style="background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:6px 8px;font-size:11px;">
               </div>
+              <div class="cfg-row">
+                <div style="display:flex;flex-direction:column;gap:2px;">
+                  <label style="font-size:10px;color:var(--muted);">Ruolo</label>
+                  <select x-model="ch.role" style="background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:6px 8px;font-size:11px;">
+                    <option>PRIMARY</option><option>SECONDARY</option><option>DISABLED</option>
+                  </select>
+                </div>
+                <div style="display:flex;flex-direction:column;gap:2px;">
+                  <label style="font-size:10px;color:var(--muted);">Precisione pos. (0=piena)</label>
+                  <input type="number" min="0" max="32" x-model.number="ch.position_precision"
+                         style="background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:6px 8px;font-size:11px;width:70px;">
+                </div>
+              </div>
+              <label class="cfg-check" style="font-size:11px;"><input type="checkbox" x-model="ch.uplink_enabled"> Uplink → MQTT</label>
+              <label class="cfg-check" style="font-size:11px;"><input type="checkbox" x-model="ch.downlink_enabled"> Downlink ← MQTT</label>
               <button @click="saveChannel(ch.index)"
                       :disabled="channelsCached"
                       style="padding:8px;font-size:11px;border:none;border-radius:4px;cursor:pointer;"
@@ -521,6 +600,56 @@
           {{ f.toggle('devSecurity.debug_log_api_enabled', 'Debug log API') }}
           <label class="cfg-check" style="color:#ff9800;"><input type="checkbox" x-model="devSecurity.is_managed"> Nodo gestito (is_managed) — blocca le modifiche locali!</label>
           {{ f.save('/api/config/device/security', 'devSecurity') }}
+        </div>
+      </div>
+    </template>
+
+    <!-- AUDIO (codec2 voice) -->
+    <template x-if="section === 'audio'">
+      <div>
+        {{ f.section_title('Audio (voce codec2)') }}
+        <div class="hint" style="margin-bottom:8px;">Richiede hardware I2S dedicato sulla board.</div>
+        <div class="cfg-col">
+          {{ f.toggle('audioMod.codec2_enabled', 'Abilitato') }}
+          {{ f.number('audioMod.ptt_pin', 'PTT pin GPIO', width='80px') }}
+          {{ f.select('audioMod.bitrate', 'Bitrate', ['CODEC2_DEFAULT', 'CODEC2_3200', 'CODEC2_2400', 'CODEC2_1600', 'CODEC2_1400', 'CODEC2_1300', 'CODEC2_1200', 'CODEC2_700', 'CODEC2_700B']) }}
+          <div class="cfg-row">
+            {{ f.number('audioMod.i2s_ws', 'I2S WS', width='70px') }}
+            {{ f.number('audioMod.i2s_sd', 'I2S SD', width='70px') }}
+            {{ f.number('audioMod.i2s_din', 'I2S DIN', width='70px') }}
+            {{ f.number('audioMod.i2s_sck', 'I2S SCK', width='70px') }}
+          </div>
+          {{ f.save('/api/config/module/audio', 'audioMod') }}
+        </div>
+      </div>
+    </template>
+
+    <!-- PAXCOUNTER -->
+    <template x-if="section === 'paxcounter'">
+      <div>
+        {{ f.section_title('Paxcounter') }}
+        <div class="hint" style="margin-bottom:8px;">Conta i dispositivi WiFi/BLE nelle vicinanze e li trasmette come telemetria.</div>
+        <div class="cfg-col">
+          {{ f.toggle('paxMod.enabled', 'Abilitato') }}
+          {{ f.number('paxMod.paxcounter_update_interval', 'Intervallo report (s, 0=default)') }}
+          <div class="cfg-row">
+            {{ f.number('paxMod.wifi_threshold', 'Soglia RSSI WiFi', width='90px') }}
+            {{ f.number('paxMod.ble_threshold', 'Soglia RSSI BLE', width='90px') }}
+          </div>
+          {{ f.save('/api/config/module/paxcounter', 'paxMod') }}
+        </div>
+      </div>
+    </template>
+
+    <!-- REMOTE HARDWARE (GPIO via mesh) -->
+    <template x-if="section === 'remotehw'">
+      <div>
+        {{ f.section_title('Remote Hardware (GPIO via mesh)') }}
+        <div class="hint" style="margin-bottom:8px;">Permette ad altri nodi di leggere/scrivere i GPIO di questa board. Abilitare con cautela.</div>
+        <div class="cfg-col">
+          {{ f.toggle('remoteHw.enabled', 'Abilitato') }}
+          {{ f.toggle('remoteHw.allow_undefined_pin_access', 'Consenti accesso a pin non dichiarati (rischioso)') }}
+          {{ f.save('/api/config/module/remote-hardware', 'remoteHw') }}
         </div>
       </div>
     </template>

--- a/templates/nodes.html
+++ b/templates/nodes.html
@@ -221,6 +221,18 @@
                   </svg>
                   Admin
                 </button>
+                <button class="action-btn" @click.stop="doFavorite(node)">
+                  <svg width="10" height="10" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.196-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.783-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"/>
+                  </svg>
+                  Preferito
+                </button>
+                <button class="action-btn" @click.stop="doIgnore(node)">
+                  <svg width="10" height="10" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"/>
+                  </svg>
+                  Ignora
+                </button>
                 <button class="action-btn" @click.stop="openForget(node)" style="color:#ef4444;border-color:#7f1d1d;">
                   <svg width="10" height="10" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
@@ -355,6 +367,18 @@
                   <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
                 </svg>
                 Admin
+              </button>
+              <button class="action-btn" @click="doFavorite(selectedNode)" style="flex-basis:calc(50% - 3px);">
+                <svg width="11" height="11" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.196-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.783-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"/>
+                </svg>
+                Preferito
+              </button>
+              <button class="action-btn" @click="doIgnore(selectedNode)" style="flex-basis:calc(50% - 3px);">
+                <svg width="11" height="11" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"/>
+                </svg>
+                Ignora
               </button>
               <button class="action-btn" @click="openForget(selectedNode)" style="flex-basis:calc(50% - 3px);color:#ef4444;border-color:#7f1d1d;">
                 <svg width="11" height="11" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
@@ -609,6 +633,21 @@ function nodesPage() {
       if (sec < 60)   return sec + 's fa'
       if (sec < 3600) return Math.floor(sec / 60) + 'm fa'
       return Math.floor(sec / 3600) + 'h fa'
+    },
+
+    doFavorite(node) {
+      fetch(`/api/nodes/${encodeURIComponent(node.id)}/favorite?on=true`, { method: 'POST' })
+        .then(r => { if (!r.ok) throw new Error()
+          if (typeof showToast === 'function') showToast('Nodo tra i preferiti della board') })
+        .catch(() => { if (typeof showToast === 'function') showToast('Operazione fallita', 'warn') })
+    },
+
+    doIgnore(node) {
+      if (!confirm(`Ignorare ${node.short_name || node.id}? La board scarterà i suoi pacchetti.`)) return
+      fetch(`/api/nodes/${encodeURIComponent(node.id)}/ignore?on=true`, { method: 'POST' })
+        .then(r => { if (!r.ok) throw new Error()
+          if (typeof showToast === 'function') showToast('Nodo ignorato dalla board') })
+        .catch(() => { if (typeof showToast === 'function') showToast('Operazione fallita', 'warn') })
     },
 
     doTraceroute(node) {

--- a/tests/test_full_protocol.py
+++ b/tests/test_full_protocol.py
@@ -1,0 +1,171 @@
+# tests/test_full_protocol.py — copertura protocollo completa:
+# canali estesi + URL/QR, LoRa avanzata, moduli audio/paxcounter/remote-hw,
+# utilità nodo (favoriti/ignorati, orario, NodeDB) e config remota.
+import pytest
+from httpx import AsyncClient, ASGITransport
+from unittest.mock import patch, AsyncMock
+
+
+@pytest.mark.asyncio
+async def test_post_channel_full_fields(mock_client):
+    from main import app
+    with patch('meshtasticd_client.set_channel', new_callable=AsyncMock) as m:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url='http://test') as ac:
+            r = await ac.post('/api/config/channels/1', json={
+                'name': 'privato', 'psk_b64': 'AQ==', 'role': 'SECONDARY',
+                'uplink_enabled': True, 'downlink_enabled': False,
+                'position_precision': 16,
+            })
+    assert r.status_code == 200
+    idx, params = m.await_args.args
+    assert idx == 1 and params['role'] == 'SECONDARY'
+    assert params['position_precision'] == 16
+
+
+@pytest.mark.asyncio
+async def test_post_channel_invalid_role_and_precision(mock_client):
+    from main import app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url='http://test') as ac:
+        r1 = await ac.post('/api/config/channels/0', json={'name': 'x', 'role': 'BOGUS'})
+        r2 = await ac.post('/api/config/channels/0', json={'name': 'x', 'position_precision': 99})
+    assert r1.status_code == 400
+    assert r2.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_get_channels_url(mock_client):
+    from main import app
+    with patch('meshtasticd_client.get_channel_url', new_callable=AsyncMock,
+               return_value='https://meshtastic.org/e/#abc'):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url='http://test') as ac:
+            r = await ac.get('/api/config/channels/url')
+    assert r.status_code == 200
+    assert r.json()['url'].startswith('https://meshtastic.org/e/#')
+
+
+@pytest.mark.asyncio
+async def test_post_channels_url_import_and_validation(mock_client):
+    from main import app
+    with patch('meshtasticd_client.set_channel_url', new_callable=AsyncMock) as m:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url='http://test') as ac:
+            ok = await ac.post('/api/config/channels/url',
+                               json={'url': 'https://meshtastic.org/e/#abc', 'add_only': True})
+            bad = await ac.post('/api/config/channels/url', json={'url': 'http://example.com'})
+    assert ok.status_code == 200
+    m.assert_awaited_once_with('https://meshtastic.org/e/#abc', True)
+    assert bad.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_get_channels_qr_svg(mock_client):
+    from main import app
+    with patch('meshtasticd_client.get_channel_url', new_callable=AsyncMock,
+               return_value='https://meshtastic.org/e/#abc'):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url='http://test') as ac:
+            r = await ac.get('/api/config/channels/qr')
+    assert r.status_code == 200
+    assert r.headers['content-type'].startswith('image/svg')
+    assert b'<svg' in r.content
+
+
+@pytest.mark.asyncio
+async def test_post_lora_advanced_fields(mock_client):
+    from main import app
+    with patch('meshtasticd_client.set_lora_config', new_callable=AsyncMock) as m:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url='http://test') as ac:
+            r = await ac.post('/api/config/lora', json={
+                'region': 'EU_868', 'modem_preset': 'LONG_FAST',
+                'hop_limit': 5, 'tx_power': 14, 'override_duty_cycle': True,
+            })
+            bad = await ac.post('/api/config/lora', json={
+                'region': 'EU_868', 'modem_preset': 'LONG_FAST', 'hop_limit': 9})
+    assert r.status_code == 200
+    assert m.await_args.args[0]['hop_limit'] == 5
+    assert bad.status_code == 400
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('endpoint,setter', [
+    ('/api/config/module/audio', 'set_audio_config'),
+    ('/api/config/module/paxcounter', 'set_paxcounter_config'),
+    ('/api/config/module/remote-hardware', 'set_remote_hardware_config'),
+])
+async def test_new_modules_roundtrip(mock_client, endpoint, setter):
+    from main import app
+    getter = setter.replace('set_', 'get_')
+    with patch(f'meshtasticd_client.{getter}', new_callable=AsyncMock,
+               return_value={'enabled': False, 'cached': True}), \
+         patch(f'meshtasticd_client.{setter}', new_callable=AsyncMock) as m:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url='http://test') as ac:
+            g = await ac.get(endpoint)
+            p = await ac.post(endpoint, json={'enabled': True})
+    assert g.status_code == 200
+    assert p.status_code == 200
+    m.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_node_favorite_and_ignore(mock_client):
+    from main import app
+    with patch('meshtasticd_client.set_node_favorite', new_callable=AsyncMock) as fav, \
+         patch('meshtasticd_client.set_node_ignored', new_callable=AsyncMock) as ign:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url='http://test') as ac:
+            r1 = await ac.post('/api/nodes/!aabbccdd/favorite?on=true')
+            r2 = await ac.post('/api/nodes/!aabbccdd/ignore?on=false')
+    assert r1.status_code == 200 and r2.status_code == 200
+    fav.assert_awaited_once_with('!aabbccdd', True)
+    ign.assert_awaited_once_with('!aabbccdd', False)
+
+
+@pytest.mark.asyncio
+async def test_sync_time_and_reset_nodedb(mock_client):
+    from main import app
+    with patch('meshtasticd_client.sync_time', new_callable=AsyncMock) as st, \
+         patch('meshtasticd_client.reset_nodedb', new_callable=AsyncMock) as rn:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url='http://test') as ac:
+            r1 = await ac.post('/api/system/sync-time')
+            r2 = await ac.post('/api/system/reset-nodedb')
+    assert r1.status_code == 200 and r2.status_code == 200
+    st.assert_awaited_once()
+    rn.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_remote_config_get_and_post(mock_client):
+    from main import app
+    with patch('meshtasticd_client.get_remote_config', new_callable=AsyncMock,
+               return_value={'region': 'EU_868'}) as g, \
+         patch('meshtasticd_client.set_remote_config', new_callable=AsyncMock) as s:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url='http://test') as ac:
+            r1 = await ac.get('/api/admin/!11223344/config/lora')
+            r2 = await ac.post('/api/admin/!11223344/config/lora',
+                               json={'region': 'EU_433', 'cached': False})
+    assert r1.status_code == 200 and r1.json()['region'] == 'EU_868'
+    assert r2.status_code == 200
+    g.assert_awaited_once_with('!11223344', 'lora')
+    # 'cached' viene scartato prima della scrittura
+    assert 'cached' not in s.await_args.args[2]
+
+
+@pytest.mark.asyncio
+async def test_remote_config_unknown_section_and_timeout(mock_client):
+    from main import app
+    with patch('meshtasticd_client.get_remote_config', new_callable=AsyncMock,
+               side_effect=TimeoutError()):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url='http://test') as ac:
+            bad = await ac.get('/api/admin/!11223344/config/bogus')
+            slow = await ac.get('/api/admin/!11223344/config/lora')
+    assert bad.status_code == 400
+    assert slow.status_code == 504
+
+
+@pytest.mark.asyncio
+async def test_apply_updates_converts_enums_and_skips_unknown():
+    import meshtasticd_client
+    from meshtastic.protobuf import config_pb2
+    cfg = config_pb2.Config.LoRaConfig()
+    meshtasticd_client._apply_updates(cfg, {
+        'region': 'EU_868', 'hop_limit': 5, 'sconosciuto': 1, 'cached': False,
+    })
+    assert cfg.region == config_pb2.Config.LoRaConfig.RegionCode.Value('EU_868')
+    assert cfg.hop_limit == 5


### PR DESCRIPTION
## Cosa cambia

Chiude tutti i gap funzionali rispetto a quanto la libreria `meshtastic` 2.7 permette.

### Canali completi
- **Ruolo** (PRIMARY/SECONDARY/DISABLED), **uplink/downlink MQTT** e **precisione posizione** per canale
- **Condivisione via URL/QR**: `GET /api/config/channels/url` (link `meshtastic.org/e/#…`) e `GET /api/config/channels/qr` (SVG, nuova dipendenza `qrcode` pura Python); **import da URL** con modalità sostituisci/aggiungi
- Route fisse registrate prima di `/channels/{idx}` per evitare la cattura dal path parametrico

### LoRa avanzata
Hop limit, TX power, frequency slot, TX enable, override duty cycle, RX boosted gain, ignore MQTT + elenco completo di regioni (18) e preset (8)

### Moduli mancanti
Audio (codec2), Paxcounter, Remote Hardware — ora **tutti i 12 moduli** Meshtastic sono configurabili dalla UI

### Utilità nodo
- Preferiti/ignorati dalla pagina Nodi (bottoni nelle azioni del nodo remoto)
- Sincronizza orario dal Pi, azzera NodeDB, modalità radioamatore (`is_licensed`), elenco ruoli completo (11)

### Config remota via mesh
- `GET/POST /api/admin/{id}/config/{sezione}` — `requestConfig`/`writeConfig` su `getNode()` con session key PKC; rilettura prima della scrittura (preserva i campi non toccati), conversione enum via reflection protobuf, timeout 120s → 504
- Nella pagina Config un selettore **"Board"** permette di configurare qualsiasi nodo remoto con gli stessi form del locale (21 sezioni remotizzabili; Nodo e Canali restano locali)

### Resta fuori (limiti libreria / scelte deliberate)
Reazioni emoji e recupero storico Store&Forward (nessuna API in meshtastic 2.7.10), BLE (kiosk fisso), DFU/OTA

## Test
- 14 test nuovi, **134 totali** passati
- Verifica visuale Playwright delle sezioni nuove (Canali con QR/import, LoRa avanzata, Audio/Paxcounter/RemoteHW, selettore Board, bottoni Preferito/Ignora) — zero errori JS

## Da verificare sul campo
- Config remota: il nodo remoto deve avere la chiave pubblica locale tra le admin key; i roundtrip mesh possono richiedere fino a 2 minuti
- Import URL canali: consigliato riavvio della board dopo l'import

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eCcrTUSo4TNRDZBBjQv98

---
_Generated by [Claude Code](https://claude.ai/code/session_011eCcrTUSo4TNRDZBBjQv98)_